### PR TITLE
fix: catch SwitchModelNotDetectedError in SSDP discovery flow

### DIFF
--- a/custom_components/netgear_plus/config_flow.py
+++ b/custom_components/netgear_plus/config_flow.py
@@ -19,6 +19,8 @@ from homeassistant.util.network import is_ipv4_address
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigFlowResult
 
+from py_netgear_plus import SwitchModelNotDetectedError
+
 from .const import DEFAULT_CONF_TIMEOUT, DEFAULT_HOST, DOMAIN
 from .errors import CannotLoginError
 from .netgear_switch import get_api
@@ -135,6 +137,8 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 get_api,
                 updated_data[CONF_HOST],  # type: ignore[arg-type]
             )
+        except SwitchModelNotDetectedError:
+            return self.async_abort(reason="switch_not_detected")
         except requests.exceptions.ConnectTimeout:
             errors["base"] = "timeout"
         except NotImplementedError:

--- a/custom_components/netgear_plus/strings.json
+++ b/custom_components/netgear_plus/strings.json
@@ -13,7 +13,8 @@
       "config": "Connection or login error: please check your configuration"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "switch_not_detected": "Switch model could not be detected during SSDP discovery"
     }
   }
 }

--- a/custom_components/netgear_plus/translations/en.json
+++ b/custom_components/netgear_plus/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "switch_not_detected": "Switch model could not be detected during SSDP discovery"
         },
         "error": {
             "config": "Connection or login error: please check your configuration"


### PR DESCRIPTION
## Summary

- Catches `SwitchModelNotDetectedError` from `py_netgear_plus` in `async_step_ssdp` and aborts the SSDP discovery flow cleanly with reason `switch_not_detected`
- Adds `switch_not_detected` abort reason to `strings.json` and `translations/en.json`

Previously, when SSDP discovered a device but `autodetect_model()` couldn't identify its model, the `SwitchModelNotDetectedError` propagated uncaught, producing repeated "Task exception was never retrieved" errors in the HA log. The fix makes SSDP discovery silently abort for unrecognised devices instead of crashing.

Closes foxey/py-netgear-plus#177

## Test plan

- [ ] SSDP discovery against an unrecognised device no longer logs unhandled task exceptions
- [ ] SSDP discovery against a supported Netgear switch still works end-to-end
- [ ] Lint / validate CI passes

> *— Ada, AI assistant acting on behalf of [@foxey](https://github.com/foxey)*